### PR TITLE
fix int to long conversion

### DIFF
--- a/android/src/main/kotlin/im/zoe/labs/flutter_floatwing/FloatWindow.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_floatwing/FloatWindow.kt
@@ -498,7 +498,9 @@ class FloatWindow(
                 // (data["id"]?.let { it as String } ?: "default").also { cfg.id = it }
                 cfg.entry = data["entry"] as String?
                 cfg.route = data["route"] as String?
-                cfg.callback = data["callback"] as Long?
+
+                val int_callback = data["callback"] as Int?
+                cfg.callback = int_callback?.toLong()
 
                 cfg.autosize = data["autosize"] as Boolean?
 


### PR DESCRIPTION
Fix for `java.lang.ClassCastException` in Flutter environment : `sdk: ">=2.12.0 <3.0.0"`.
Reference to issue: [java.lang.ClassCastException in Flutter environment : sdk: ">=2.12.0 <3.0.0".](https://github.com/jiusanzhou/flutter_floatwing/issues/3#issuecomment-1353310368)

Solved by first casting to `Int?` and then to `Long?`.