### PR TITLE
fix callback java.lang.Long cannot be cast to java.lang.Integer

### DIFF
--- a/android/src/main/kotlin/im/zoe/labs/flutter_floatwing/FloatWindow.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_floatwing/FloatWindow.kt
@@ -499,7 +499,7 @@ class FloatWindow(
                 cfg.entry = data["entry"] as String?
                 cfg.route = data["route"] as String?
 
-                val int_callback = data["callback"] as Int?
+                val int_callback = data["callback"] as Number?
                 cfg.callback = int_callback?.toLong()
 
                 cfg.autosize = data["autosize"] as Boolean?


### PR DESCRIPTION
[√] Flutter (Channel stable, 3.7.5, on Microsoft Windows [版本 10.0.22621.1265], locale en-US)
    • Flutter version 3.7.5 on channel stable at D:\Github\flutter
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision c07f788888 (5 days ago), 2023-02-22 17:52:33 -0600
    • Engine revision 0f359063c4
    • Dart version 2.19.2
    • DevTools version 2.20.1
    • Pub download mirror https://mirror.sjtu.edu.cn/dart-pub
    • Flutter download mirror https://mirror.sjtu.edu.cn

https://github.com/jiusanzhou/flutter_floatwing/issues/3#issuecomment-1354295037 not work
